### PR TITLE
Idempotency - comment on already opened exact title/label match existing issues rather than creating new ones

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""
-Check for new versions.
-"""
-from concourse import ConcourseGithubIssuesResource
-
-
-if __name__ == "__main__":
-    ConcourseGithubIssuesResource.check_main()

--- a/assets/in
+++ b/assets/in
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""
-Fetch a given resource.
-"""
-from concourse import ConcourseGithubIssuesResource
-
-
-if __name__ == "__main__":
-    ConcourseGithubIssuesResource.in_main()

--- a/assets/out
+++ b/assets/out
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""
-Update a resource.
-"""
-from concourse import ConcourseGithubIssuesResource
-
-
-if __name__ == "__main__":
-    ConcourseGithubIssuesResource.out_main()

--- a/concourse.py
+++ b/concourse.py
@@ -104,10 +104,16 @@ class ConcourseGithubIssuesResource(ConcourseResource):
             state=self.issue_state, labels=self.issue_labels or []
         )
 
-    def get_exact_title_match(self, title: str):
+    def get_exact_title_match(
+        self, title: str, state: Literal["open", "closed"]
+    ) -> list[Issue]:
         all_pipeline_issues = self.get_all_issues()
 
-        return [issue for issue in all_pipeline_issues if (issue.title == title or "")]
+        return [
+            issue
+            for issue in all_pipeline_issues
+            if (issue.title == title or "") and (state == state)
+        ]
 
     def get_matching_issues(self):
         all_pipeline_issues = self.get_all_issues()
@@ -153,8 +159,10 @@ class ConcourseGithubIssuesResource(ConcourseResource):
 
         candidate_issue_title = self.get_title_from_build(build_metadata)
         print(f"publish_new_version: {candidate_issue_title=}")
+        print(f"publish_new_version: {labels}")
+        print(f"publish_new_version: {assignees}")
 
-        already_exists = self.get_exact_title_match(candidate_issue_title)
+        already_exists = self.get_exact_title_match(candidate_issue_title, state="open")
         print(f"publish_new_version: {already_exists=}")
 
         if not already_exists:

--- a/concourse.py
+++ b/concourse.py
@@ -41,9 +41,11 @@ class ConcourseGithubIssuesVersion(Version, SortableVersionMixin):
     def __lt__(self, other: "ConcourseGithubIssuesVersion"):
         if self.issue_state == "closed":
             return datetime.strptime(
-                ISO_8601_FORMAT, self.issue_closed_at  # type: ignore[arg-type]
+                ISO_8601_FORMAT,
+                self.issue_closed_at,  # type: ignore[arg-type]
             ) < datetime.strptime(
-                ISO_8601_FORMAT, other.issue_closed_at  # type: ignore[arg-type]
+                ISO_8601_FORMAT,
+                other.issue_closed_at,  # type: ignore[arg-type]
             )
         else:
             return datetime.strptime(
@@ -161,9 +163,9 @@ class ConcourseGithubIssuesResource(ConcourseResource):
             )
         else:
             working_issue = already_exists[0]
-            comment_body = f"{build_metadata.BUILD_NAME} run by "
-            f"{build_metadata.BUILD_CREATED_BY} failed. See "
-            f"{build_metadata.build_url()} for details."
+            comment_body = (
+                f"Build failed. See {build_metadata.build_url()} for details."
+            )
             working_issue.create_comment(comment_body)
 
         return self._to_version(working_issue), {}

--- a/concourse.py
+++ b/concourse.py
@@ -109,7 +109,7 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         self, title: str, state: Literal["open", "closed"]
     ) -> list[Issue]:
         all_pipeline_issues = self.get_all_issues()
-        print(f"get_exact_title_match: {all_pipeline_issues=}")
+        print(f"get_exact_title_match: {list(all_pipeline_issues)=}")
 
         print(f"get_exact_title_match: {title=} {state=}")
         unsorted = [

--- a/concourse.py
+++ b/concourse.py
@@ -112,23 +112,14 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         all_pipeline_issues = self.get_all_issues(issue_state=state)
 
         print(f"get_exact_title_match: {title=} {state=}")
-        # unsorted = [
-        #     issue
-        #     for issue in all_pipeline_issues
-        #     if (issue.title == title or "") and (issue.state == state)
-        # ]
-        unsorted = []
-        for issue in all_pipeline_issues:
-            if (issue.title == title or "") and (issue.state == state):
-                print(f"get_exact_title_match: matched! {issue.title=} {issue.state=}")
-                unsorted.append(issue)
-            else:
-                print(
-                    f"get_exact_title_match: fail: {title=} {issue.title=} {state=} {issue.state=}"
-                )
+        unsorted = [
+            issue
+            for issue in all_pipeline_issues
+            if (issue.title == title or "") and (issue.state == state)
+        ]
 
         print(f"get_exact_title_match: {unsorted=}")
-        sorted_issues = sorted(unsorted, key=lambda issue: issue.number)
+        sorted_issues = sorted(unsorted, key=lambda issue: issue.number, reverse=True)
         print(f"get_exact_title_match: {sorted_issues=}")
         return sorted_issues
 
@@ -199,11 +190,13 @@ class ConcourseGithubIssuesResource(ConcourseResource):
                 assignees=assignees or [],
                 labels=labels or [],
             )
+            print(f"created issue: {working_issue=}")
         else:
             working_issue = already_exists[0]
             comment_body = (
                 f"Build failed. See {build_metadata.build_url()} for details."
             )
+            print(f"about to comment on {working_issue=} with {comment_body=}")
             working_issue.create_comment(comment_body)
 
         return self._to_version(working_issue), {}

--- a/concourse.py
+++ b/concourse.py
@@ -146,6 +146,11 @@ class ConcourseGithubIssuesResource(ConcourseResource):
             issue_file.write(json.dumps(version.to_flat_dict()))
         return version, {}
 
+    def get_issue_body_from_build(self, build_metadata):
+        body = (self.issue_body_template.format(**build_metadata.__dict__),)
+        # This feels gross. Is this adding another tuple? Not sure :)
+        body += build_metadata.build_url()
+
     def get_title_from_build(self, build_metadata):
         return self.issue_title_template.format(**build_metadata.__dict__)
 
@@ -176,7 +181,6 @@ class ConcourseGithubIssuesResource(ConcourseResource):
                 title=candidate_issue_title,
                 assignees=assignees or [],
                 labels=labels or [],
-                body=self.issue_body_template.format(**build_metadata.__dict__),
             )
         else:
             working_issue = already_exists[0]

--- a/concourse.py
+++ b/concourse.py
@@ -120,6 +120,7 @@ class ConcourseGithubIssuesResource(ConcourseResource):
 
     def fetch_new_versions(self, previous_version=None):
         matching_issues = self.get_matching_issues()
+        print(f"fetch_new_versions: {matching_issues=}")
         sorted_issues = sorted(matching_issues, key=lambda issue: issue.number)
         try:
             previous_issue_number = previous_version.number
@@ -151,8 +152,10 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         # already exists
 
         candidate_issue_title = self.get_title_from_build(build_metadata)
+        print(f"publish_new_version: {candidate_issue_title=}")
 
         already_exists = self.get_exact_title_match(candidate_issue_title)
+        print(f"publish_new_version: {already_exists=}")
 
         if not already_exists:
             working_issue = self.repo.create_issue(

--- a/concourse.py
+++ b/concourse.py
@@ -112,7 +112,7 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         return [
             issue
             for issue in all_pipeline_issues
-            if (issue.title == title or "") and (state == state)
+            if (issue.title == title or "") and (issue.state == state)
         ]
 
     def get_matching_issues(self):
@@ -159,8 +159,8 @@ class ConcourseGithubIssuesResource(ConcourseResource):
 
         candidate_issue_title = self.get_title_from_build(build_metadata)
         print(f"publish_new_version: {candidate_issue_title=}")
-        print(f"publish_new_version: {labels}")
-        print(f"publish_new_version: {assignees}")
+        print(f"publish_new_version: {labels=}")
+        print(f"publish_new_version: {assignees=}")
 
         already_exists = self.get_exact_title_match(candidate_issue_title, state="open")
         print(f"publish_new_version: {already_exists=}")

--- a/concourse.py
+++ b/concourse.py
@@ -110,21 +110,27 @@ class ConcourseGithubIssuesResource(ConcourseResource):
     ) -> list[Issue]:
         all_pipeline_issues = self.get_all_issues()
 
+        print(f"get_exact_title_match: {title=} {state=}")
         unsorted = [
             issue
             for issue in all_pipeline_issues
             if (issue.title == title or "") and (issue.state == state)
         ]
-        return sorted(unsorted, key=lambda issue: issue.number)
+        print(f"get_exact_title_match: {unsorted=}")
+        sorted_issues = sorted(unsorted, key=lambda issue: issue.number)
+        print(f"get_exact_title_match: {sorted_issues=}")
+        return sorted_issues
 
     def get_matching_issues(self):
         all_pipeline_issues = self.get_all_issues()
 
-        return [
+        matching_issues = [
             issue
             for issue in all_pipeline_issues
-            if issue.title.startswith(self.issue_prefix or "")
+            if issue.title.startswith(self.issue_prefix)
         ]
+        print(f"get_matching_issues: {matching_issues=}")
+        return matching_issues
 
     def fetch_new_versions(self, previous_version=None):
         matching_issues = self.get_matching_issues()

--- a/concourse.py
+++ b/concourse.py
@@ -100,16 +100,16 @@ class ConcourseGithubIssuesResource(ConcourseResource):
     def _from_version(self, version: ConcourseGithubIssuesVersion) -> Issue:
         return self.repo.get_issue(int(version.issue_number))
 
-    def get_all_issues(self):
-        print(f"get_all_issues: {self.issue_state=}")
-        return self.repo.get_issues(
-            state=self.issue_state, labels=self.issue_labels or []
-        )
+    def get_all_issues(self, issue_state=None):
+        if not issue_state:
+            issue_state = self.issue_state
+
+        return self.repo.get_issues(state=issue_state, labels=self.issue_labels or [])
 
     def get_exact_title_match(
         self, title: str, state: Literal["open", "closed"]
     ) -> list[Issue]:
-        all_pipeline_issues = self.get_all_issues()
+        all_pipeline_issues = self.get_all_issues(issue_state=state)
 
         print(f"get_exact_title_match: {title=} {state=}")
         # unsorted = [

--- a/concourse.py
+++ b/concourse.py
@@ -97,15 +97,22 @@ class ConcourseGithubIssuesResource(ConcourseResource):
     def _from_version(self, version: ConcourseGithubIssuesVersion) -> Issue:
         return self.repo.get_issue(int(version.issue_number))
 
-    def fetch_new_versions(self, previous_version=None):
-        all_pipeline_issues = self.repo.get_issues(
+    def get_all_issues(self):
+        return self.repo.get_issues(
             state=self.issue_state, labels=self.issue_labels or []
         )
-        matching_issues = [
+
+    def get_matching_issues(self):
+        all_pipeline_issues = self.get_all_issues()
+
+        return [
             issue
             for issue in all_pipeline_issues
             if issue.title.startswith(self.issue_prefix or "")
         ]
+
+    def fetch_new_versions(self, previous_version=None):
+        matching_issues = self.get_matching_issues()
         sorted_issues = sorted(matching_issues, key=lambda issue: issue.number)
         try:
             previous_issue_number = previous_version.number

--- a/concourse.py
+++ b/concourse.py
@@ -128,7 +128,7 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         matching_issues = [
             issue
             for issue in all_pipeline_issues
-            if issue.title.startswith(self.issue_prefix)
+            if issue.title.startswith(self.issue_prefix or "")
         ]
         print(f"get_matching_issues: {matching_issues=}")
         return matching_issues

--- a/concourse.py
+++ b/concourse.py
@@ -109,6 +109,7 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         self, title: str, state: Literal["open", "closed"]
     ) -> list[Issue]:
         all_pipeline_issues = self.get_all_issues()
+        print(f"get_exact_title_match: {all_pipeline_issues=}")
 
         print(f"get_exact_title_match: {title=} {state=}")
         unsorted = [

--- a/concourse.py
+++ b/concourse.py
@@ -111,16 +111,13 @@ class ConcourseGithubIssuesResource(ConcourseResource):
     ) -> list[Issue]:
         all_pipeline_issues = self.get_all_issues(issue_state=state)
 
-        print(f"get_exact_title_match: {title=} {state=}")
         unsorted = [
             issue
             for issue in all_pipeline_issues
             if (issue.title == title or "") and (issue.state == state)
         ]
 
-        print(f"get_exact_title_match: {unsorted=}")
         sorted_issues = sorted(unsorted, key=lambda issue: issue.number, reverse=True)
-        print(f"get_exact_title_match: {sorted_issues=}")
         return sorted_issues
 
     def get_matching_issues(self):
@@ -131,12 +128,10 @@ class ConcourseGithubIssuesResource(ConcourseResource):
             for issue in all_pipeline_issues
             if issue.title.startswith(self.issue_prefix or "")
         ]
-        print(f"get_matching_issues: {matching_issues=}")
         return matching_issues
 
     def fetch_new_versions(self, previous_version=None):
         matching_issues = self.get_matching_issues()
-        print(f"fetch_new_versions: {matching_issues=}")
         sorted_issues = sorted(matching_issues, key=lambda issue: issue.number)
         try:
             previous_issue_number = previous_version.number
@@ -173,16 +168,11 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         # already exists
 
         candidate_issue_title = self.get_title_from_build(build_metadata)
-        print(f"publish_new_version: {candidate_issue_title=}")
-        print(f"publish_new_version: {labels=}")
-        print(f"publish_new_version: {assignees=}")
 
         already_exists = self.get_exact_title_match(candidate_issue_title, state="open")
 
         if len(already_exists) > 1:
             print("Warning: There are multiple matches for the desired issue title!")
-
-        print(f"publish_new_version: {already_exists=}")
 
         if not already_exists:
             working_issue = self.repo.create_issue(

--- a/concourse.py
+++ b/concourse.py
@@ -112,11 +112,21 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         print(f"get_exact_title_match: {list(all_pipeline_issues)=}")
 
         print(f"get_exact_title_match: {title=} {state=}")
-        unsorted = [
-            issue
-            for issue in all_pipeline_issues
-            if (issue.title == title or "") and (issue.state == state)
-        ]
+        # unsorted = [
+        #     issue
+        #     for issue in all_pipeline_issues
+        #     if (issue.title == title or "") and (issue.state == state)
+        # ]
+        unsorted = []
+        for issue in all_pipeline_issues:
+            if (issue.title == title or "") and (issue.state == state):
+                print(f"get_exact_title_match: matched! {issue.title=} {issue.state=}")
+                unsorted.append(issue)
+            else:
+                print(
+                    f"get_exact_title_match: fail: {title=} {issue.title=} {state=} {issue.state=}"
+                )
+
         print(f"get_exact_title_match: {unsorted=}")
         sorted_issues = sorted(unsorted, key=lambda issue: issue.number)
         print(f"get_exact_title_match: {sorted_issues=}")

--- a/concourse.py
+++ b/concourse.py
@@ -101,6 +101,7 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         return self.repo.get_issue(int(version.issue_number))
 
     def get_all_issues(self):
+        print(f"get_all_issues: {self.issue_state=}")
         return self.repo.get_issues(
             state=self.issue_state, labels=self.issue_labels or []
         )
@@ -109,7 +110,6 @@ class ConcourseGithubIssuesResource(ConcourseResource):
         self, title: str, state: Literal["open", "closed"]
     ) -> list[Issue]:
         all_pipeline_issues = self.get_all_issues()
-        print(f"get_exact_title_match: {list(all_pipeline_issues)=}")
 
         print(f"get_exact_title_match: {title=} {state=}")
         # unsorted = [

--- a/issue_create_test_pipeline.yaml
+++ b/issue_create_test_pipeline.yaml
@@ -4,7 +4,7 @@ jobs:
   name: run-github-issue-integ
   plan:
   - get: test_pipeline_issues
-    trigger: true
+    trigger: false
   - config:
       image_resource:
         name: ""

--- a/trigger_test_pipeline.yaml
+++ b/trigger_test_pipeline.yaml
@@ -33,7 +33,7 @@ resource_types:
     tag: latest
   type: registry-image
 resources:
-- check_every: 24h0m0s
+- check_every: 24h
   icon: github
   name: test_pipeline_issues
   source:


### PR DESCRIPTION
# What are the relevant tickets?

Closes https://github.com/mitodl/ol-infrastructure/issues/1858

# Description (What does it do?)

If the github-issue-resource is used in a put, it will create a new issue with the parameters specified, but before it does it checks to see if an issue with identical attributes already exists, if it does, it instead comments on that issue with the relevant details including the build URL.

# How can this be tested?

Ran against concourse-workflow repo with [this pipeline](https://cicd.odl.mit.edu/teams/infrastructure/pipelines/issue-create-test/jobs/run-github-issue-integ/builds/315).  See [this issue](https://github.com/mitodl/concourse-workflow/issues/456) for an example of the idempotency in action.

