### PR TITLE
feat: Add a metadata dict that includes the build URL

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""
-Check for new versions.
-"""
-from concourse import ConcourseGithubIssuesResource
-
-
-if __name__ == "__main__":
-    ConcourseGithubIssuesResource.check_main()

--- a/assets/in
+++ b/assets/in
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""
-Fetch a given resource.
-"""
-from concourse import ConcourseGithubIssuesResource
-
-
-if __name__ == "__main__":
-    ConcourseGithubIssuesResource.in_main()

--- a/assets/out
+++ b/assets/out
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""
-Update a resource.
-"""
-from concourse import ConcourseGithubIssuesResource
-
-
-if __name__ == "__main__":
-    ConcourseGithubIssuesResource.out_main()


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
- Add type information for function signatures
- Add a build metadata dict to include the build URL for splatting into format strings
- Delete assets directory since it is auto-generated in the Docker build