### PR TITLE
Fix: #45 - actually return something if both issues are closed.

### DIFF
--- a/concourse.py
+++ b/concourse.py
@@ -62,7 +62,7 @@ class ConcourseGithubIssuesVersion(Version, SortableVersionMixin):
                 ISO_8601_FORMAT,
             )
         else:
-            int(self.issue_number) < int(other.issue_number)
+            return int(self.issue_number) < int(other.issue_number)
 
 
 class ConcourseGithubIssuesResource(SelfOrganisingConcourseResource):


### PR DESCRIPTION
### What are the relevant tickets?
#45 

### Description (What does it do?)
Right now, if both issues are closed in a version comparison, we fall off the end of the comparison without returning.

That's not good :)

### How can this be tested?
Observe effect in test pipeline.