### PR TITLE
Github application support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,54 @@
 # ol-concourse-github-issues
 A Concourse resource to manipulate Github Issues
 
-# To install (TODO: MORE DETAIL NEEDED)
+## Install (TODO: MORE DETAIL NEEDED)
 
 You can find the resource on [dockerhub](https://hub.docker.com/r/mitodl/ol-concourse-github-issues)
 
-# To use:
+## Usage
 
 Your pipeline should include a source block like:
 
 ```
-access_token: Github access token
+auth_method: "app" or "token". Defaults to token if not specified
+access_token: a personal Github access token. Required if auth method == app
+app_id: a Github application ID. Required if auth method == app
+app_installation_id: a Github application installation ID. Required if auth_method == app
+private_ssh_key: The complete application RSA key generated for a Github application. Required if auth_method == app
 repository: Github repo in which to detect / create issues
 issue_state: One of "open" or "closed". Defaults to "closed"
-issue_prefix: prefix issue titles must contain to match.
-labels: labels required to match.
+issue_prefix: prefix issue titles must contain to match
+labels: labels required to match
 assignees: optional assignees list to use when creating issues
 ```
+
+Documentation on setting up a personal access token can be found [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app)
+Documentation on setting up a github application can be found [here](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app), [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation) and [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps)
 
 You can find example pipeline definitions for:
 
 - [Triggering a task when a Github issue is created](trigger_test_pipeline.yaml)
 - [Creating a New Github Issue When A Task
 Completes](issue_create_test_pipeline.yaml)
+
+## Building
+
+With Docker:
+```
+docker build --platform=linux/amd64 .
+```
+
+With Earthly:
+
+On Apple Silicon, first follow instructions [here](https://docs.earthly.dev/docs/guides/multi-platform#apple-silicon-m1-and-m2-processors)
+```
+earthly --platform=linux/amd64 +build
+```
+
+## Testing
+
+```
+poetry install
+poetry run python3 -m concoursetools . -r concourse.py
+check < payload.json
+```

--- a/README.md
+++ b/README.md
@@ -22,14 +22,19 @@ labels: labels required to match
 assignees: optional assignees list to use when creating issues
 ```
 
-Documentation on setting up a personal access token can be found [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app)
-Documentation on setting up a github application can be found [here](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app), [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation) and [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps)
-
 You can find example pipeline definitions for:
 
 - [Triggering a task when a Github issue is created](trigger_test_pipeline.yaml)
 - [Creating a New Github Issue When A Task
 Completes](issue_create_test_pipeline.yaml)
+
+## App / Token Permissions
+
+- Token: `project, read:org, repo`
+- Application Installation: `Repository->Contents->Read and Write`, `Respository->Issues->Read and Write`, `Repository->Metadata->Read-only` and `Repository->Pull requests->Read and Write`
+
+Documentation on setting up a personal access token can be found [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app)
+Documentation on setting up a github application can be found [here](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app), [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation) and [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps)
 
 ## Building
 

--- a/concourse.py
+++ b/concourse.py
@@ -97,7 +97,6 @@ class ConcourseGithubIssuesResource(SelfOrganisingConcourseResource):
                     app_installation_id
                 )
             )
-        print(self.gh.get_rate_limit().core.remaining)
         if self.gh.get_rate_limit().core.remaining == 0:
             sys.exit(1)
         self.repo = self.gh.get_repo(repository)

--- a/payload_check_app.json
+++ b/payload_check_app.json
@@ -1,0 +1,12 @@
+{
+  "source": {
+    "auth_method": "app",
+    "app_id": "<application id as an int>",
+    "app_installation_id": "<application installation id as an int>",
+    "private_ssh_key": "<application SSH key as string with \n here>",
+    "issue_prefix": "[bot] Pulumi ol-infrastructure-edxapp-application.mitx applications.edxapp.mitx.CI deployed.",
+    "issue_state": "closed",
+    "issue_title_template": "[bot] Pulumi ol-infrastructure-edxapp-application.mitx applications.edxapp.mitx.CI deployed.",
+    "repository": "mitodl/concourse-workflow"
+  }
+}

--- a/payload_check_token.json
+++ b/payload_check_token.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "access_token": "<personal github token here>",
+    "issue_prefix": "[bot] Pulumi ol-infrastructure-edxapp-application.mitx applications.edxapp.mitx.CI deployed.",
+    "issue_state": "closed",
+    "issue_title_template": "[bot] Pulumi ol-infrastructure-edxapp-application.mitx applications.edxapp.mitx.CI deployed.",
+    "repository": "mitodl/concourse-workflow"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ol_concourse_github_issues"
-version = "0.1.0"
+version = "0.1.1"
 description = "concourse.io resource for manipulating Github Issues"
 authors = ["Chris Patti <feoh@feoh.org>"]
 license = "MIT"


### PR DESCRIPTION
### What are the relevant tickets?
Closes #62 

### Description (What does it do?)
- Added support to authenticating as a github application. 
- Added a simple error code exit for when the rate limit is exhausted rather than executing further.
- Updated documentation
- Added simple json payloads for testing the check functionality.

### How can this be tested?
Will need to use the existing application configured in `mitodl` organization and installed into the `concourse-workflow` repo (or you can create a new one, but that is a lot of work...)  Update the payload json files with the missing secret information and use something like the following. 

```
poetry install
poetry run python3 -m concoursetools . -r concourse.py
check < payload.json
```
